### PR TITLE
Deal with specs that don't contain tests

### DIFF
--- a/reporter/jasmine2_reporter.js
+++ b/reporter/jasmine2_reporter.js
@@ -109,6 +109,10 @@ var Jasmine2Reporter = function (htmlReportPath, screenshotPath, config) {
         suites.forEach(function (suite, index) {
 
             var flag = true;
+            
+            if(!suite.specs){
+                return;
+            }
 
             suite.specs.forEach(function (spec, specIndex) {
 


### PR DESCRIPTION
This addresses a bug where tests suites that don't contain tests trip up the reporter.

 For instance a jasmine specs like the following:
```
describe('test category', function(){
 describe('category A', function(){
  it(...);
  it(...)
 });
 describe('category b', function(){
   it(...);
   it(...)
 });
});
```